### PR TITLE
Added HTTPS protocol to bower-installer in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   "homepage": "https://github.com/bessdsv/karma-jasmine-jquery",
   "dependencies": {
     "bower": "^1.3.9",
-    "bower-installer": "https://github.com/bessdsv/bower-installer.git#temp"
+    "bower-installer": "git+https://github.com/bessdsv/bower-installer.git#temp"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   "homepage": "https://github.com/bessdsv/karma-jasmine-jquery",
   "dependencies": {
     "bower": "^1.3.9",
-    "bower-installer": "git://github.com/bessdsv/bower-installer.git#temp"
+    "bower-installer": "https://github.com/bessdsv/bower-installer.git#temp"
   }
 }


### PR DESCRIPTION
Using HTTPS instead of just the git protocol circumvents certain corporate firewall policies. Now it uses one or the other, whichever is able to connect.