### PR TITLE
remove "git://" for bower-installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   "homepage": "https://github.com/bessdsv/karma-jasmine-jquery",
   "dependencies": {
     "bower": "^1.3.9",
-    "bower-installer": "git+https://github.com/bessdsv/bower-installer.git#temp"
+    "bower-installer": "https://github.com/bessdsv/bower-installer.git#temp"
   }
 }


### PR DESCRIPTION
git:// not supported by github.

ref:  https://github.blog/2021-09-01-improving-git-protocol-security-github/

https://github.com/bessdsv/karma-jasmine-jquery/issues/23