### PR TITLE
fix: updated the git url for bower-installer to fix the unauthenticated git protocol error

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   "homepage": "https://github.com/bessdsv/karma-jasmine-jquery",
   "dependencies": {
     "bower": "^1.3.9",
-    "bower-installer": "git+https://github.com/bessdsv/bower-installer.git#temp"
+    "bower-installer": "https://github.com/bessdsv/bower-installer.git#temp"
   }
 }


### PR DESCRIPTION
as noted here: #23 and by Github: https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git
Github no longer allows unauthenticated `git://` URLs
this is causing issues like failures in: https://github.com/openedx/edx-analytics-dashboard/pull/1240